### PR TITLE
[Fix] 신고하기 메뉴 클릭 시 메뉴 팝오버 닫히도록 코드 수정

### DIFF
--- a/src/features/popover-menu/menu-items/report-menu-item.tsx
+++ b/src/features/popover-menu/menu-items/report-menu-item.tsx
@@ -28,7 +28,10 @@ export function ReportMenuItem({
 
 	const menuItemProps: PopoverMenuItemProps = {
 		text: "신고하기",
-		onClick: () => openReportModal(reportType, userId, boardId),
+		onClick: () => {
+			openReportModal(reportType, userId, boardId);
+			onClosePopover?.();
+		},
 		className,
 	};
 


### PR DESCRIPTION
## 🔍 작업 유형

<!-- 해당하는 항목에 x 표시 -->

-   [x] 🔧 fix (버그 수정)


## 📄 작업 내용

<!-- 이번 PR에서 변경된 내용을 설명해주세요 -->
- 신고하기 메뉴 아이템 클릭시 팝오버 메뉴가 닫히지 않는데 모달과 z-index가 동일해서 모달의 backdrop에 가려지지 않고 같이 보이는 문제가 발생했습니다.
- 이를 해결하기 위해 신고하기 클릭시 모달을 열면서 팝오버 메뉴는 닫히도록 코드를 수정하였습니다.

## 🔗 관련 이슈

<!-- 관련된 이슈가 있다면 링크해주세요 -->

## ✅ 체크리스트

-   [ ] 코드가 정상적으로 동작합니다
-   [ ] 변경 사항이 기존 기능에 영향을 주지 않습니다
-   [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)
-   [ ] 문서를 업데이트했습니다 (해당하는 경우)

## 🖼️ 🖥 구현 결과 (선택사항)

<img width="1024" height="689" alt="image" src="https://github.com/user-attachments/assets/808cf6bc-bea7-400d-9c8b-b58a1aeffecb" />


<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

## ✔ 리뷰 요구사항

<!-- 리뷰어에게 요청하고 싶은 부분을 작성해주세요 -->

## 📋 참고 문서

<!-- 참고 문서가 있다면 작성해주세요 -->
